### PR TITLE
fix bugs for powershell 5

### DIFF
--- a/PSSodium/PSSodium.psd1
+++ b/PSSodium/PSSodium.psd1
@@ -9,10 +9,10 @@
 @{
 
 # Script module or binary module file associated with this manifest.
-RootModule = 'PSSodium'
+RootModule = 'PSSodium.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.4.0'
+ModuleVersion = '0.4.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @('Core', 'Desktop')

--- a/PSSodium/PSSodium.psm1
+++ b/PSSodium/PSSodium.psm1
@@ -5,7 +5,7 @@ switch ($true) {
     $IsMacOS {
         Import-Module "$PSScriptRoot/osx-x64/PSSodium.dll"
     }
-    $IsWindows {
+    default {
         if ([System.Environment]::Is64BitProcess) {
             Import-Module "$PSScriptRoot/win-x64/PSSodium.dll"
         } else {


### PR DESCRIPTION
* In .psd1 file, change RootModule value to true module file name
  * this fixes an issue where powershell thinks no module files exist.
* Change switch condition `$IsWindows` to `default` since `$IsWindows`
wasn't added until powershell core.