### PR TITLE
Add support for Apple silicon

### DIFF
--- a/PSSodium.csproj
+++ b/PSSodium.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-preview-06">
+    <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Sodium.Core" Version="1.2.3" />
+    <PackageReference Include="Sodium.Core" Version="1.3.3" />
   </ItemGroup>
 
 </Project>

--- a/PSSodium/PSSodium.psd1
+++ b/PSSodium/PSSodium.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSSodium.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.4.1'
+ModuleVersion = '0.4.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @('Core', 'Desktop')

--- a/PSSodium/PSSodium.psm1
+++ b/PSSodium/PSSodium.psm1
@@ -3,7 +3,12 @@ switch ($true) {
         Import-Module "$PSScriptRoot/linux-x64/PSSodium.dll"
     }
     $IsMacOS {
-        Import-Module "$PSScriptRoot/osx-x64/PSSodium.dll"
+        if("$(sysctl -n machdep.cpu.brand_string)" -Like 'Apple*'){
+            Import-Module "$PSScriptRoot/osx-arm64/PSSodium.dll"
+        } else {
+            Import-Module "$PSScriptRoot/osx-x64/PSSodium.dll"
+        }
+        
     }
     default {
         if ([System.Environment]::Is64BitProcess) {

--- a/build.ps1
+++ b/build.ps1
@@ -1,8 +1,9 @@
 $targetRuntimes = @(
-    'osx-x64'
     'linux-x64'
     'win-x64'
     'win-x86'
+    'osx-arm64'
+    'osx-x64'
 )
 
 foreach ($tr in $targetRuntimes) {


### PR DESCRIPTION
Hi,

I just added supprt for running on Apple M1(+)  CPU. I needed to update sodium to support this as well. I haven't been able to test it on a Intel Mac but it works fine on Windows (Core and Desktop) and of course on my M1 Pro.